### PR TITLE
Create central event bus for playing audio

### DIFF
--- a/etc/modules/HelpersModule.ts
+++ b/etc/modules/HelpersModule.ts
@@ -38,11 +38,11 @@ export default class HelpersModule implements Module {
             }) as Logger;
         });
 
-        container.add(tokens.musicBotAudioPlayerFactory, AudioPlayerFactory, [
+        container.share(tokens.musicBotAudioPlayerFactory, AudioPlayerFactory, [
             tokens.musicBotClient,
             tokens.musicBotAudioEventBus,
         ]);
-        container.add(tokens.welcomeBotAudioPlayerFactory, AudioPlayerFactory, [
+        container.share(tokens.welcomeBotAudioPlayerFactory, AudioPlayerFactory, [
             tokens.welcomeBotClient,
             tokens.welcomeBotAudioEventBus,
         ]);

--- a/etc/modules/HelpersModule.ts
+++ b/etc/modules/HelpersModule.ts
@@ -1,10 +1,11 @@
-import { Container, Module, Token } from "containor";
-import { AudioPlayerFactory } from "../../src/helpers/AudioPlayerFactory";
-import { SpotifyAPIHelper } from "../../src/helpers/SpotifyAPIHelper";
-import { YoutubeAPIHelper } from "../../src/helpers/YoutubeAPIHelper";
-import tokens from "../tokens";
-import { createLogger, transports, format, Logger } from 'winston';
+import { Container, Module, Token } from 'containor';
 import * as path from 'path';
+import { createLogger, format, Logger, transports } from 'winston';
+import { AudioPlayerFactory } from '../../src/helpers/AudioPlayerFactory';
+import { AudioEventBus } from '../../src/helpers/EventBus';
+import { SpotifyAPIHelper } from '../../src/helpers/SpotifyAPIHelper';
+import { YoutubeAPIHelper } from '../../src/helpers/YoutubeAPIHelper';
+import tokens from '../tokens';
 
 const { Console, File } = transports;
 const { combine, timestamp, printf } = format;
@@ -14,35 +15,40 @@ const lineFormat = printf(({ level, message, timestamp }) => {
 
 export default class HelpersModule implements Module {
     public provides: Token[] = [
-        tokens.musicBotAudioPlayerFactory, 
+        tokens.musicBotAudioPlayerFactory,
         tokens.welcomeBotAudioPlayerFactory,
         tokens.spotifyApiHelper,
         tokens.youtubeApiHelper,
-        tokens.logger
+        tokens.logger,
     ];
 
     public register(container: Container): void {
         container.add(tokens.logger, (): Logger => {
             return createLogger({
                 level: 'silly',
-                format: combine(
-                    timestamp(),
-                    lineFormat
-                ),
+                format: combine(timestamp(), lineFormat),
                 transports: [
                     new Console(),
                     new File({
                         filename: path.basename(container.get(tokens.config).directory.logs),
                         dirname: path.dirname(container.get(tokens.config).directory.logs),
-                        maxsize: 1e+7
-                    })
-                ]
-            }) as Logger
+                        maxsize: 1e7,
+                    }),
+                ],
+            }) as Logger;
         });
 
-        container.add(tokens.musicBotAudioPlayerFactory, AudioPlayerFactory, [tokens.musicBotClient]);
-        container.add(tokens.welcomeBotAudioPlayerFactory, AudioPlayerFactory, [tokens.welcomeBotClient]);
+        container.add(tokens.musicBotAudioPlayerFactory, AudioPlayerFactory, [
+            tokens.musicBotClient,
+            tokens.musicBotAudioEventBus,
+        ]);
+        container.add(tokens.welcomeBotAudioPlayerFactory, AudioPlayerFactory, [
+            tokens.welcomeBotClient,
+            tokens.welcomeBotAudioEventBus,
+        ]);
         container.add(tokens.spotifyApiHelper, SpotifyAPIHelper, [tokens.config, tokens.logger]);
         container.add(tokens.youtubeApiHelper, YoutubeAPIHelper, [tokens.logger]);
+        container.share(tokens.musicBotAudioEventBus, AudioEventBus, []);
+        container.share(tokens.welcomeBotAudioEventBus, AudioEventBus, []);
     }
 }

--- a/etc/modules/MediaModule.ts
+++ b/etc/modules/MediaModule.ts
@@ -36,7 +36,7 @@ export default class MediaModule implements Module {
 
         container.add(tokens.pausedStateHandler, PausedStateHandler, [
             tokens.botStatus,
-            tokens.musicBotAudioPlayer,
+            tokens.musicBotAudioPlayerFactory,
             tokens.queueManager,
             tokens.channelManager,
         ]);

--- a/etc/modules/MediaModule.ts
+++ b/etc/modules/MediaModule.ts
@@ -29,7 +29,7 @@ export default class MediaModule implements Module {
 
         container.add(tokens.playingStateHandler, PlayingStateHandler, [
             tokens.botStatus,
-            tokens.musicBotAudioPlayer,
+            tokens.musicBotAudioPlayerFactory,
             tokens.queueManager,
             tokens.channelManager,
         ]);

--- a/etc/modules/MediaModule.ts
+++ b/etc/modules/MediaModule.ts
@@ -22,7 +22,7 @@ export default class MediaModule implements Module {
             tokens.botStatus,
             tokens.logger,
             tokens.mediaTypeProvider,
-            tokens.musicBotAudioPlayer,
+            tokens.musicBotAudioPlayerFactory,
             tokens.queueManager,
             tokens.channelManager,
         ]);

--- a/etc/tokens.ts
+++ b/etc/tokens.ts
@@ -1,4 +1,3 @@
-import { AudioPlayer } from '@discordjs/voice';
 import { token } from 'containor';
 import { Client, ClientUser } from 'discord.js';
 import { Logger } from 'winston';
@@ -47,7 +46,6 @@ export default {
     welcomeBotAudioPlayerFactory: token<AudioPlayerFactory>('welcomeBotAudioPlayerFactory'),
     spotifyApiHelper: token<SpotifyAPIHelper>('spotifyApiHelper'),
     youtubeApiHelper: token<YoutubeAPIHelper>('youtubeApiHelper'),
-    musicBotAudioPlayer: token<AudioPlayer>('musicBotAudioPlayer'),
     welcomeBotAudioEventBus: token<AudioEventBus>('welcomeBotAudioEventBus'),
     musicBotAudioEventBus: token<AudioEventBus>('musicBotAudioEventBus'),
 

--- a/etc/tokens.ts
+++ b/etc/tokens.ts
@@ -9,6 +9,7 @@ import { WelcomeTuneBot } from '../src/bot/WelcomeTuneBot';
 import { ChannelManager } from '../src/channel/ChannelManager';
 import { CommandMapFactory } from '../src/command/CommandMapFactory';
 import { AudioPlayerFactory } from '../src/helpers/AudioPlayerFactory';
+import { AudioEventBus } from '../src/helpers/EventBus';
 import { SpotifyAPIHelper } from '../src/helpers/SpotifyAPIHelper';
 import { YoutubeAPIHelper } from '../src/helpers/YoutubeAPIHelper';
 import { MediaFilePlayer } from '../src/media/MediaFilePlayer';
@@ -47,6 +48,8 @@ export default {
     spotifyApiHelper: token<SpotifyAPIHelper>('spotifyApiHelper'),
     youtubeApiHelper: token<YoutubeAPIHelper>('youtubeApiHelper'),
     musicBotAudioPlayer: token<AudioPlayer>('musicBotAudioPlayer'),
+    welcomeBotAudioEventBus: token<AudioEventBus>('welcomeBotAudioEventBus'),
+    musicBotAudioEventBus: token<AudioEventBus>('musicBotAudioEventBus'),
 
     // Media
     mediaPlayer: token<MediaPlayer>('mediaPlayer'),

--- a/src/command/SearchAndAddCommand.ts
+++ b/src/command/SearchAndAddCommand.ts
@@ -39,7 +39,6 @@ export class SearchAndAddCommand implements ICommand {
                     return;
                 }
             } else {
-                console.log(3);
                 await this.queueManager.addMedia({
                     type: 'youtube',
                     url: cmd.body,

--- a/src/helpers/AudioPlayerFactory.ts
+++ b/src/helpers/AudioPlayerFactory.ts
@@ -3,7 +3,7 @@ import { Client, Message, VoiceState } from 'discord.js';
 import { AudioEventBus } from './EventBus';
 
 export interface IAudioPlayerFactory {
-    createSubscribedAudioPlayer(voice: VoiceState): AudioPlayer;
+    getAudioPlayer(): AudioPlayer;
 }
 
 export class AudioPlayerFactory {
@@ -18,7 +18,7 @@ export class AudioPlayerFactory {
         return this.audioPlayer;
     }
 
-    public initialize(): void {
+    private initialize(): void {
         this.client.on('messageCreate', (message: Message<boolean>) => {
             if (!message?.member?.voice?.channel) {
                 return;
@@ -28,7 +28,7 @@ export class AudioPlayerFactory {
         });
     }
 
-    public createSubscribedAudioPlayer(voice: VoiceState): AudioPlayer {
+    private createSubscribedAudioPlayer(voice: VoiceState): AudioPlayer {
         if (this.channelId && this.channelId !== voice.channelId) {
             return this.audioPlayer; // Don't go to a different channel.
         }

--- a/src/helpers/AudioPlayerFactory.ts
+++ b/src/helpers/AudioPlayerFactory.ts
@@ -1,28 +1,67 @@
-import { joinVoiceChannel, createAudioPlayer } from '@discordjs/voice';
-import { Client, VoiceState } from 'discord.js';
-import { AudioPlayer } from '@discordjs/voice';
+import { AudioPlayer, createAudioPlayer, joinVoiceChannel } from '@discordjs/voice';
+import { Client, Message, VoiceState } from 'discord.js';
+import { AudioEventBus } from './EventBus';
 
 export interface IAudioPlayerFactory {
     createSubscribedAudioPlayer(voice: VoiceState): AudioPlayer;
 }
 
 export class AudioPlayerFactory {
-    constructor(private readonly loggedInClient: Client) { }
-    
-    createSubscribedAudioPlayer(voice: VoiceState): AudioPlayer {
+    private audioPlayer: AudioPlayer;
+    private channelId: string;
+
+    constructor(private readonly client: Client, private readonly audioEventBus: AudioEventBus) {
+        this.initialize();
+    }
+
+    public getAudioPlayer(): AudioPlayer | undefined {
+        return this.audioPlayer;
+    }
+
+    public initialize(): void {
+        this.client.on('messageCreate', (message: Message<boolean>) => {
+            if (!message?.member?.voice?.channel) {
+                return;
+            }
+
+            this.createSubscribedAudioPlayer(message.member.voice);
+        });
+    }
+
+    public createSubscribedAudioPlayer(voice: VoiceState): AudioPlayer {
+        if (this.channelId && this.channelId !== voice.channelId) {
+            return this.audioPlayer; // Don't go to a different channel.
+        }
+
         const connection = joinVoiceChannel({
             channelId: voice.channelId,
             guildId: voice.guild.id,
             adapterCreator: voice.guild.voiceAdapterCreator,
-            group: this.loggedInClient.user.id,
+            group: this.client.user.id,
             selfMute: false,
-            selfDeaf: false
+            selfDeaf: false,
         });
 
-        const audioPlayer = createAudioPlayer();
+        this.channelId = voice.channelId;
 
-        connection.subscribe(audioPlayer);
+        if (!this.audioPlayer) {
+            this.audioPlayer = createAudioPlayer();
 
-        return audioPlayer;
+            this.sendEventsToEventBus();
+        }
+
+        connection.subscribe(this.audioPlayer);
+
+        return this.audioPlayer;
+    }
+
+    private sendEventsToEventBus() {
+        this.audioPlayer.on('error', (error) => this.audioEventBus.emit('error', error));
+        this.audioPlayer.on('debug', (message) => this.audioEventBus.emit('debug', message));
+        this.audioPlayer.on('stateChange', (oldState, newState) =>
+            this.audioEventBus.emit('stateChange', oldState, newState)
+        );
+        this.audioPlayer.on('subscribe', (subscription) => this.audioEventBus.emit('subscribe', subscription));
+        this.audioPlayer.on('unsubscribe', (unsubscribe) => this.audioEventBus.emit('unsubscribe', unsubscribe));
     }
 }

--- a/src/helpers/EventBus.ts
+++ b/src/helpers/EventBus.ts
@@ -1,0 +1,3 @@
+import { EventEmitter } from 'events';
+
+export class AudioEventBus extends EventEmitter {}

--- a/src/media/MediaFilePlayer.ts
+++ b/src/media/MediaFilePlayer.ts
@@ -1,6 +1,6 @@
-import { AudioPlayer, createAudioResource } from "@discordjs/voice";
-import {  VoiceState } from "discord.js";
-import { AudioPlayerFactory } from "../helpers/AudioPlayerFactory";
+import { AudioPlayer, createAudioResource } from '@discordjs/voice';
+import { VoiceState } from 'discord.js';
+import { IAudioPlayerFactory } from '../helpers/AudioPlayerFactory';
 
 export interface IMediaFilePlayer {
     playFile(fileName: string, channel: VoiceState): void;
@@ -10,13 +10,13 @@ export interface IMediaFilePlayer {
 export class MediaFilePlayer implements IMediaFilePlayer {
     private audioPlayer: AudioPlayer;
 
-    public constructor(private readonly audioPlayerFactory: AudioPlayerFactory) {}
-    
+    public constructor(private readonly audioPlayerFactory: IAudioPlayerFactory) {}
+
     public playFile(fileName: string, channel: VoiceState): void {
         if (!this.audioPlayer) {
-            this.audioPlayer = this.audioPlayerFactory.createSubscribedAudioPlayer(channel);
+            this.audioPlayer = this.audioPlayerFactory.getAudioPlayer();
         }
-        
+
         this.audioPlayer.play(createAudioResource(fileName));
     }
 }

--- a/src/media/state/IdleStateHandler.ts
+++ b/src/media/state/IdleStateHandler.ts
@@ -1,6 +1,7 @@
-import { AudioPlayer, createAudioResource, StreamType } from '@discordjs/voice';
+import { createAudioResource, StreamType } from '@discordjs/voice';
 import { BotStatus } from 'src/bot/BotStatus';
 import { IChannelManager } from 'src/channel/ChannelManager';
+import { AudioPlayerFactory } from 'src/helpers/AudioPlayerFactory';
 import { IMediaTypeProvider } from 'src/mediatypes/IMediaTypeProvider';
 import { IQueueManager } from 'src/queue/QueueManager';
 import { Logger } from 'winston';
@@ -12,7 +13,7 @@ export default class IdleStateHandler extends AbstractMediaPlayerStateHandler {
         private readonly status: BotStatus,
         private readonly logger: Logger,
         private readonly mediaTypeProvider: IMediaTypeProvider,
-        private readonly audioPlayer: AudioPlayer,
+        private readonly audioPlayerFactory: AudioPlayerFactory,
         private readonly queueManager: IQueueManager,
         private readonly channelManager: IChannelManager
     ) {
@@ -39,7 +40,13 @@ export default class IdleStateHandler extends AbstractMediaPlayerStateHandler {
 
         const currentSong = await type.getStream(item);
 
-        this.audioPlayer.play(createAudioResource(currentSong, { inputType: StreamType.Arbitrary }));
+        const audioPlayer = this.audioPlayerFactory.getAudioPlayer();
+
+        if (!audioPlayer) {
+            throw new Error('Audio player not found');
+        }
+
+        audioPlayer.play(createAudioResource(currentSong, { inputType: StreamType.Arbitrary }));
 
         this.status.setBanner(`Playing ${item.name}`);
         await this.channelManager.sendTrackPlayingMessage(item);

--- a/src/media/state/IdleStateHandler.ts
+++ b/src/media/state/IdleStateHandler.ts
@@ -1,7 +1,7 @@
 import { createAudioResource, StreamType } from '@discordjs/voice';
 import { BotStatus } from 'src/bot/BotStatus';
 import { IChannelManager } from 'src/channel/ChannelManager';
-import { AudioPlayerFactory } from 'src/helpers/AudioPlayerFactory';
+import { IAudioPlayerFactory } from 'src/helpers/AudioPlayerFactory';
 import { IMediaTypeProvider } from 'src/mediatypes/IMediaTypeProvider';
 import { IQueueManager } from 'src/queue/QueueManager';
 import { Logger } from 'winston';
@@ -13,7 +13,7 @@ export default class IdleStateHandler extends AbstractMediaPlayerStateHandler {
         private readonly status: BotStatus,
         private readonly logger: Logger,
         private readonly mediaTypeProvider: IMediaTypeProvider,
-        private readonly audioPlayerFactory: AudioPlayerFactory,
+        private readonly audioPlayerFactory: IAudioPlayerFactory,
         private readonly queueManager: IQueueManager,
         private readonly channelManager: IChannelManager
     ) {

--- a/src/media/state/PausedStateHandler.ts
+++ b/src/media/state/PausedStateHandler.ts
@@ -1,14 +1,14 @@
-import { AudioPlayer } from '@discordjs/voice';
 import { BotStatus } from 'src/bot/BotStatus';
 import { IChannelManager } from 'src/channel/ChannelManager';
 import { IQueueManager } from 'src/queue/QueueManager';
+import { AudioPlayerFactory } from '../../helpers/AudioPlayerFactory';
 import AbstractMediaPlayerStateHandler from './AbstractMediaPlayerStateHandler';
 import { PlayerState } from './Types';
 
 export default class PausedStateHandler extends AbstractMediaPlayerStateHandler {
     constructor(
         private readonly status: BotStatus,
-        private readonly audioPlayer: AudioPlayer,
+        private readonly audioPlayerFactory: AudioPlayerFactory,
         private readonly queueManager: IQueueManager,
         private readonly channelManager: IChannelManager
     ) {
@@ -16,7 +16,13 @@ export default class PausedStateHandler extends AbstractMediaPlayerStateHandler 
     }
 
     async play(): Promise<void> {
-        if (!this.audioPlayer.unpause()) {
+        const audioPlayer = this.audioPlayerFactory.getAudioPlayer();
+
+        if (!audioPlayer) {
+            throw new Error('Player not yet created.');
+        }
+
+        if (!audioPlayer.unpause()) {
             throw new Error('Failed to unpause player');
         }
 
@@ -29,7 +35,13 @@ export default class PausedStateHandler extends AbstractMediaPlayerStateHandler 
     }
 
     async stop(silent: boolean = false): Promise<void> {
-        if (!this.audioPlayer.stop()) {
+        const audioPlayer = this.audioPlayerFactory.getAudioPlayer();
+
+        if (!audioPlayer) {
+            throw new Error('Player not yet created.');
+        }
+
+        if (!audioPlayer.stop()) {
             throw new Error('Failed to stop player.');
         }
 

--- a/src/media/state/PlayingStateHandler.ts
+++ b/src/media/state/PlayingStateHandler.ts
@@ -1,14 +1,14 @@
-import { AudioPlayer } from '@discordjs/voice';
 import { BotStatus } from 'src/bot/BotStatus';
 import { IChannelManager } from 'src/channel/ChannelManager';
 import { IQueueManager } from 'src/queue/QueueManager';
+import { AudioPlayerFactory } from '../../helpers/AudioPlayerFactory';
 import AbstractMediaPlayerStateHandler from './AbstractMediaPlayerStateHandler';
 import { PlayerState } from './Types';
 
 export default class PlayingStateHandler extends AbstractMediaPlayerStateHandler {
     constructor(
         private readonly status: BotStatus,
-        private readonly audioPlayer: AudioPlayer,
+        private readonly audioPlayerFactory: AudioPlayerFactory,
         private readonly queueManager: IQueueManager,
         private readonly channelManager: IChannelManager
     ) {
@@ -16,7 +16,13 @@ export default class PlayingStateHandler extends AbstractMediaPlayerStateHandler
     }
 
     async stop(silent: boolean = false): Promise<void> {
-        if (!this.audioPlayer.stop()) {
+        const audioPlayer = this.audioPlayerFactory.getAudioPlayer();
+
+        if (!audioPlayer) {
+            throw new Error('Player not yet created.');
+        }
+
+        if (!audioPlayer.stop()) {
             throw new Error('Failed to stop player.');
         }
 
@@ -38,7 +44,13 @@ export default class PlayingStateHandler extends AbstractMediaPlayerStateHandler
     }
 
     async pause(): Promise<void> {
-        if (!this.audioPlayer.pause()) {
+        const audioPlayer = this.audioPlayerFactory.getAudioPlayer();
+
+        if (!audioPlayer) {
+            throw new Error('Player not yet created.');
+        }
+
+        if (!audioPlayer.pause()) {
             throw new Error('Failed to pause player.');
         }
 

--- a/tests/unit/media/MediaPlayer.spec.ts
+++ b/tests/unit/media/MediaPlayer.spec.ts
@@ -1,8 +1,8 @@
-import { AudioPlayer } from '@discordjs/voice';
 import { mock } from 'jest-mock-extended';
 import { Logger } from 'winston';
 import { BotStatus } from '../../../src/bot/BotStatus';
 import { IChannelManager } from '../../../src/channel/ChannelManager';
+import { AudioEventBus } from '../../../src/helpers/EventBus';
 import { MediaPlayer } from '../../../src/media/MediaPlayer';
 import IMediaPlayerStateHandler from '../../../src/media/state/IMediaPlayerStateHandler';
 import { PlayerState } from '../../../src/media/state/Types';
@@ -12,15 +12,15 @@ let mediaPlayer: MediaPlayer;
 
 const status = mock<BotStatus>();
 const logger = mock<Logger>();
-const audioPlayer = mock<AudioPlayer>();
 const queueManager = mock<IQueueManager>();
 const channelManager = mock<IChannelManager>();
 const stateHandler = mock<IMediaPlayerStateHandler>();
+const eventBus = mock<AudioEventBus>();
 
 beforeEach(() => {
     jest.resetAllMocks();
 
-    mediaPlayer = new MediaPlayer(status, logger, audioPlayer, queueManager, channelManager, [stateHandler]);
+    mediaPlayer = new MediaPlayer(status, logger, queueManager, channelManager, [stateHandler], eventBus);
 
     stateHandler.getApplicableStateName.mockReturnValue(PlayerState.Idle);
 });

--- a/tests/unit/media/state/PausedStateHandler.spec.ts
+++ b/tests/unit/media/state/PausedStateHandler.spec.ts
@@ -1,5 +1,6 @@
 import { AudioPlayer } from '@discordjs/voice';
 import { mock } from 'jest-mock-extended';
+import { AudioPlayerFactory } from '../../../../src/helpers/AudioPlayerFactory';
 import PausedStateHandler from '../../../../src/media/state/PausedStateHandler';
 import { getValidMediaItem } from '../../../fixtures/mediaItemFixtures';
 import { BotStatus } from './../../../../src/bot/BotStatus';
@@ -10,16 +11,29 @@ let handler: PausedStateHandler;
 
 const status = mock<BotStatus>();
 const audioPlayer = mock<AudioPlayer>();
+const audioPlayerFactory = mock<AudioPlayerFactory>();
 const queueManager = mock<IQueueManager>();
 const channelManager = mock<IChannelManager>();
 
 beforeEach(() => {
     jest.resetAllMocks();
 
-    handler = new PausedStateHandler(status, audioPlayer, queueManager, channelManager);
+    audioPlayerFactory.getAudioPlayer.mockReturnValue(audioPlayer);
+
+    handler = new PausedStateHandler(status, audioPlayerFactory, queueManager, channelManager);
 });
 
 describe('stop()', () => {
+    it('Should throw an error when no audio player could be created', async () => {
+        audioPlayerFactory.getAudioPlayer.mockReturnValue(undefined);
+
+        try {
+            await handler.stop();
+        } catch (e) {
+            expect(e).toBeDefined();
+        }
+    });
+
     it('Should throw an error when stopping the audio player fails', async () => {
         audioPlayer.stop.mockReturnValue(false);
 
@@ -71,6 +85,16 @@ describe('stop()', () => {
 });
 
 describe('play()', () => {
+    it('Should throw an error when no audio player could be created', async () => {
+        audioPlayerFactory.getAudioPlayer.mockReturnValue(undefined);
+
+        try {
+            await handler.play();
+        } catch (e) {
+            expect(e).toBeDefined();
+        }
+    });
+
     it('Should throw an error when unpausing the audio player fails', async () => {
         audioPlayer.unpause.mockReturnValue(false);
 


### PR DESCRIPTION
The problem was that, in order to play audio, you need a channel. And in order to get events from that audioplayer, it already needs to exist. 

This race condition can be avoided by having a centralized event bus, so basically what the factory does :)

Can be prettier, but at least it works and 90% is tested. Still don't know how to test event emitters properly.