### PR TITLE
Fix link between audio player and event bus

### DIFF
--- a/etc/modules/MediaModule.ts
+++ b/etc/modules/MediaModule.ts
@@ -49,7 +49,7 @@ export default class MediaModule implements Module {
             container.get(tokens.pausedStateHandler),
         ]);
 
-        container.add(tokens.mediaPlayer, MediaPlayer, [
+        container.share(tokens.mediaPlayer, MediaPlayer, [
             tokens.botStatus,
             tokens.logger,
             tokens.queueManager,

--- a/src/helpers/EventBus.ts
+++ b/src/helpers/EventBus.ts
@@ -1,3 +1,8 @@
 import { EventEmitter } from 'events';
 
+export enum AudioEventBusStatus {
+    AudioPlayerIdle = 'audioPlayer.idle',
+    AudioPlayerError = 'audioPlayer.error',
+}
+
 export class AudioEventBus extends EventEmitter {}

--- a/src/media/MediaPlayer.ts
+++ b/src/media/MediaPlayer.ts
@@ -1,9 +1,8 @@
-import { AudioPlayerStatus } from '@discordjs/voice';
 import { IChannelManager } from 'src/channel/ChannelManager';
 import { IQueueManager } from 'src/queue/QueueManager';
 import { Logger } from 'winston';
 import { BotStatus } from '../bot/BotStatus';
-import { AudioEventBus } from '../helpers/EventBus';
+import { AudioEventBus, AudioEventBusStatus } from '../helpers/EventBus';
 import IMediaPlayerStateHandler from './state/IMediaPlayerStateHandler';
 import { PlayerState } from './state/Types';
 
@@ -20,13 +19,13 @@ export class MediaPlayer {
     ) {}
 
     public initializePlayer(): void {
-        this.eventBus.on('error', async (error) => {
+        this.eventBus.on(AudioEventBusStatus.AudioPlayerError, async (error) => {
             this.logger.error('Error playing song: ', { error });
             await this.channelManager.sendErrorMessage(`Error Playing Song: ${error.message}`);
             await this.skip();
         });
 
-        this.eventBus.on(AudioPlayerStatus.Idle, async () => {
+        this.eventBus.on(AudioEventBusStatus.AudioPlayerIdle, () => {
             if (!this.isInState(PlayerState.Playing)) {
                 this.logger.debug('Not doing anything with idle state, as previous state was not playing.');
                 return;
@@ -34,7 +33,7 @@ export class MediaPlayer {
 
             this.logger.debug('Stream done');
             this.setPlayerState(PlayerState.Idle);
-            await this.play();
+            this.play();
         });
 
         this.status.emptyBanner();

--- a/tests/unit/media/MediaPlayer.spec.ts
+++ b/tests/unit/media/MediaPlayer.spec.ts
@@ -2,7 +2,7 @@ import { mock } from 'jest-mock-extended';
 import { Logger } from 'winston';
 import { BotStatus } from '../../../src/bot/BotStatus';
 import { IChannelManager } from '../../../src/channel/ChannelManager';
-import { AudioEventBus } from '../../../src/helpers/EventBus';
+import { AudioEventBus, AudioEventBusStatus } from '../../../src/helpers/EventBus';
 import { MediaPlayer } from '../../../src/media/MediaPlayer';
 import IMediaPlayerStateHandler from '../../../src/media/state/IMediaPlayerStateHandler';
 import { PlayerState } from '../../../src/media/state/Types';
@@ -15,14 +15,53 @@ const logger = mock<Logger>();
 const queueManager = mock<IQueueManager>();
 const channelManager = mock<IChannelManager>();
 const stateHandler = mock<IMediaPlayerStateHandler>();
-const eventBus = mock<AudioEventBus>();
+let eventBus: AudioEventBus;
 
 beforeEach(() => {
     jest.resetAllMocks();
 
+    eventBus = new AudioEventBus();
     mediaPlayer = new MediaPlayer(status, logger, queueManager, channelManager, [stateHandler], eventBus);
 
     stateHandler.getApplicableStateName.mockReturnValue(PlayerState.Idle);
+});
+
+describe('Initialize', () => {
+    describe('stateChange event', () => {
+        it('Should not play when previous player state was not playing', () => {
+            mediaPlayer.initializePlayer();
+
+            eventBus.emit(AudioEventBusStatus.AudioPlayerIdle);
+
+            expect(logger.debug).toHaveBeenCalled();
+            expect(stateHandler.play).not.toHaveBeenCalled();
+        });
+
+        it('Should play new song when player is idle', async () => {
+            mediaPlayer.initializePlayer();
+
+            await mediaPlayer.play();
+
+            eventBus.emit(AudioEventBusStatus.AudioPlayerIdle);
+
+            expect(stateHandler.play).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('error event', () => {
+        it('Should log error, send to channel and skip song on error', async () => {
+            mediaPlayer.initializePlayer();
+
+            eventBus.emit(AudioEventBusStatus.AudioPlayerError, new Error());
+            expect.assertions(3);
+
+            jest.runAllTimers();
+
+            expect(logger.error).toHaveBeenCalled();
+            expect(channelManager.sendErrorMessage).toHaveBeenCalledWith(expect.stringContaining('Error Playing Song'));
+            expect(channelManager.sendErrorMessage).toHaveBeenCalledTimes(1);
+        });
+    });
 });
 
 describe.each(['play', 'stop', 'pause'])('play/stop/pause()', (value: string) => {


### PR DESCRIPTION
For in loops for enums in emitters apparently do not work. Also decoupled the media player to the native discord audio player by using own statuses.